### PR TITLE
Adding of API prefix support for Passport.js service

### DIFF
--- a/files/api/user/services/passport.js
+++ b/files/api/user/services/passport.js
@@ -220,7 +220,7 @@ passport.loadStrategies = function loadStrategies() {
       let callback = strategy.callback;
 
       if (!callback) {
-        callback = path.join('auth', key, 'callback');
+        callback = path.join(strapi.config.prefix, 'auth', key, 'callback');
       }
 
       if (key === 'google') {


### PR DESCRIPTION
I'm using the application prefix to separate REST API, but when I want to use the Passport service, the callback URL don't take in charge this prefix.
