### PR TITLE
err.message to actually get the error

### DIFF
--- a/files/api/user/controllers/Auth.js
+++ b/files/api/user/controllers/Auth.js
@@ -24,7 +24,7 @@ module.exports = {
     yield strapi.api.user.services.passport.callback(this, function (err, user) {
       if (err || !user) {
         ctx.status = 400;
-        return ctx.body = err || {};
+        return ctx.body = err.message || {};
       } else {
         ctx.status = 200;
         if (_.contains(ctx.originalUrl, 'local')) {


### PR DESCRIPTION
ctx.body = err does not parse the error. The resulting JSON is {}.

err.message to get the actual error message.
