### PR TITLE
Delete role policy for users security

### DIFF
--- a/files/api/user/config/routes.json
+++ b/files/api/user/config/routes.json
@@ -18,7 +18,8 @@
       "controller": "User",
       "action": "update",
       "policies": [
-        "isAuthorized"
+        "isAuthorized",
+        "deleteRoles"
       ]
     },
     "DELETE /user/:id": {

--- a/files/api/user/controllers/User.js
+++ b/files/api/user/controllers/User.js
@@ -7,25 +7,6 @@
 module.exports = {
 
   /**
-   * Kind of router to create user entry
-   *
-   * @param {Object} this.request
-   *
-   * @return {Object}
-   */
-
-  create: function * () {
-    var params = this.request.body;
-    var controller = 'user';
-
-    if (params.hasOwnProperty('template') && strapi.controllers[controller + params.template]) {
-      controller += params.template;
-    }
-
-    this.body = yield strapi.controllers[controller].add(params, this);
-  },
-
-  /**
    * Kind of router to get user entry/entries
    *
    * @param {Object} this.request

--- a/files/api/user/policies/deleteRoles.js
+++ b/files/api/user/policies/deleteRoles.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * Delete the `roles` object to prevent security issues.
+ *
+ * @param next
+ */
+
+exports.deleteRoles = function * (next) {
+  delete this.request.body.roles;
+
+  yield next;
+};


### PR DESCRIPTION
Delete the field `roles` in PUT requests to prevent security issues.
